### PR TITLE
 Add recent files menu and store recently opened files

### DIFF
--- a/src/contributors.html
+++ b/src/contributors.html
@@ -16,5 +16,6 @@
 <p><span class="ext" data-url="https://github.com/ivysrono">@ivysrono</span></p>
 <p><span class="ext" data-url="https://github.com/zakki">@zakki (Kensuke Matsuzaki)</span></p>
 <p><span class="ext" data-url="https://github.com/hebaeba">@hebaeba</span></p>
+<p><span class="ext" data-url="https://github.com/qcgm1978">@qcgm1978 (Youth)</span></p>
 
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -455,26 +455,26 @@ function menu_template(win) {
     const insert_if = (pred, ...items) => pred ? items : []
     const lz_white = AI.leelaz_for_white_p()
     const dup = until_current_move_p =>
-        () => duplicate_sequence(until_current_move_p, true)
-        const get_recent_files=function() {
-            const files = store.get('recent_files') || [];
-            const item = files.map(file => ({
-                label: file,
-                click() { load_sgf_etc(file) }
-            }))
-            return item;
-        }
-        const file_menu = menu('File', [
-            item('New game', 'CmdOrCtrl+N', (this_item, win) => ask_new_game(win), true),
-            R.in_match ?
+          () => duplicate_sequence(until_current_move_p, true)
+    const get_recent_files=function() {
+        const files = store.get('recent_files') || [];
+        const item = files.map(file => ({
+            label: file,
+            click() { load_sgf_etc(file) }
+        }))
+        return item;
+    }
+    const file_menu = menu('File', [
+        item('New game', 'CmdOrCtrl+N', (this_item, win) => ask_new_game(win), true),
+        R.in_match ?
             item('Stop match', 'Shift+G',
-            (this_item, win) => stop_match(window_prop(win).window_id), true) :
+                 (this_item, win) => stop_match(window_prop(win).window_id), true) :
             item('Match vs. AI', 'Shift+G', (this_item, win) => start_match(win), true),
-            item('Pair match', undefined,
-            (this_item, win) => start_match(win, 3), true, !(R.in_match && R.in_pair_match)),
-            sep,
-            item('Open SGF etc....', 'CmdOrCtrl+O', open_sgf_etc, true),
-            menu('Recent Files', get_recent_files()),
+        item('Pair match', undefined,
+             (this_item, win) => start_match(win, 3), true, !(R.in_match && R.in_pair_match)),
+        sep,
+        item('Open SGF etc....', 'CmdOrCtrl+O', open_sgf_etc, true),
+        menu('Recent Files', get_recent_files()),
         item('Save SGF with analysis...', 'CmdOrCtrl+S', () => save_sgf(true), true),
         item('Save SGF...', 'CmdOrCtrl+Shift+S', () => save_sgf(false), true),
         sep,

--- a/src/main.js
+++ b/src/main.js
@@ -455,17 +455,26 @@ function menu_template(win) {
     const insert_if = (pred, ...items) => pred ? items : []
     const lz_white = AI.leelaz_for_white_p()
     const dup = until_current_move_p =>
-          () => duplicate_sequence(until_current_move_p, true)
-    const file_menu = menu('File', [
-        item('New game', 'CmdOrCtrl+N', (this_item, win) => ask_new_game(win), true),
-        R.in_match ?
+        () => duplicate_sequence(until_current_move_p, true)
+        const get_recent_files=function() {
+            const files = store.get('recent_files') || [];
+            const item = files.map(file => ({
+                label: file,
+                click() { load_sgf_etc(file) }
+            }))
+            return item;
+        }
+        const file_menu = menu('File', [
+            item('New game', 'CmdOrCtrl+N', (this_item, win) => ask_new_game(win), true),
+            R.in_match ?
             item('Stop match', 'Shift+G',
-                 (this_item, win) => stop_match(window_prop(win).window_id), true) :
+            (this_item, win) => stop_match(window_prop(win).window_id), true) :
             item('Match vs. AI', 'Shift+G', (this_item, win) => start_match(win), true),
-        item('Pair match', undefined,
-             (this_item, win) => start_match(win, 3), true, !(R.in_match && R.in_pair_match)),
-        sep,
-        item('Open SGF etc....', 'CmdOrCtrl+O', open_sgf_etc, true),
+            item('Pair match', undefined,
+            (this_item, win) => start_match(win, 3), true, !(R.in_match && R.in_pair_match)),
+            sep,
+            item('Open SGF etc....', 'CmdOrCtrl+O', open_sgf_etc, true),
+            menu('Recent Files', get_recent_files()),
         item('Save SGF with analysis...', 'CmdOrCtrl+S', () => save_sgf(true), true),
         item('Save SGF...', 'CmdOrCtrl+Shift+S', () => save_sgf(false), true),
         sep,
@@ -2003,6 +2012,10 @@ function open_sgf_etc_in(dir, proc) {
     select_files('Select SGF etc.', dir).forEach(proc || load_sgf_etc)
 }
 function load_sgf_etc(filename) {
+    const files = store.get('recent_files') || []
+    if (!files.includes(filename)) {
+        set_stored('recent_files', [filename, ...files])
+    }
     const res = sgf_str => {read_sgf(sgf_str, filename); update_all()}
     const rej = () => {load_sgf(filename); update_all()}
     XYZ2SGF.fileToConvertedString(filename).then(res, rej)

--- a/src/main.js
+++ b/src/main.js
@@ -2009,7 +2009,7 @@ function load_sgf_etc(filename) {
     const rej = () => {load_sgf(filename); update_all()}
     XYZ2SGF.fileToConvertedString(filename).then(res, rej)
     const recent = new Set([filename, ...store.get('recent_files', [])])
-    store.set('recent_files', [...recent].slice(0, option.max_resent_files))
+    store.set('recent_files', [...recent].slice(0, option.max_recent_files))
 }
 function load_sgf(filename, internally) {
     read_sgf(fs.readFileSync(filename, {encoding: 'utf8'}), filename, internally)

--- a/src/option.js
+++ b/src/option.js
@@ -26,6 +26,7 @@ const default_option = {
     sgf_dir: undefined,
     exercise_dir: 'exercise',
     max_cached_engines: 3,
+    max_resent_files: 10,
     face_image_rule: null,
     preset: [{label: "leelaz", engine: ["leelaz", "-g", "-w", "network.gz"]}],
     record_note_to_SGF: false,

--- a/src/option.js
+++ b/src/option.js
@@ -26,7 +26,7 @@ const default_option = {
     sgf_dir: undefined,
     exercise_dir: 'exercise',
     max_cached_engines: 3,
-    max_resent_files: 10,
+    max_recent_files: 10,
     face_image_rule: null,
     preset: [{label: "leelaz", engine: ["leelaz", "-g", "-w", "network.gz"]}],
     record_note_to_SGF: false,


### PR DESCRIPTION
This commit adds a "Recent Files" submenu to the "File" menu that displays recently opened SGF files. It also stores the list of recent files in the browser storage and updates it whenever a new file is loaded, so the recent files stay in sync across browser sessions.

<img width="815" alt="截屏2023-12-01 23 41 55" src="https://github.com/kaorahi/lizgoban/assets/3024299/100f05d2-ff13-4ec5-af4f-cbda84203a00">
